### PR TITLE
Nitpick: Better .gitignore?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 authenticationService/log.log
 saleService/log.log
+node_modules


### PR DESCRIPTION
I usually tend to have a `.gitignore` file handy for most of the stacks I use. I think there can be a lot of other entries here.